### PR TITLE
Better Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,16 +1,24 @@
 FROM node:20-alpine AS builder
+
+RUN npm install -g pnpm
+
 WORKDIR /app
 COPY package*.json .
+COPY pnpm-lock.yaml .
+RUN pnpm install --frozen-lockfile
+
 COPY . .
-RUN npm install
-RUN npm run build
-RUN npm prune --production
+RUN pnpm run build
+RUN pnpm prune --production
 
 FROM node:20-alpine
+
 WORKDIR /app
 COPY --from=builder /app/dist dist/
 COPY --from=builder /app/node_modules node_modules/
+COPY --from=builder /app/drizzle drizzle/
 COPY package.json .
+
 EXPOSE 8080
 ENV NODE_ENV=production
 CMD [ "node", "/app/dist/index.js" ]


### PR DESCRIPTION
Use pnpm with a frozen lockfile and copy over drizzle files for database migrations. Also perform copies and installs in an order that maximizes caching between builds.