### PR TITLE
Fixed "coordiates" spell error

### DIFF
--- a/backend/drizzle/0000_confused_black_panther.sql
+++ b/backend/drizzle/0000_confused_black_panther.sql
@@ -7,6 +7,6 @@ CREATE TABLE IF NOT EXISTS "buildings" (
 CREATE TABLE IF NOT EXISTS "rooms" (
 	"id" serial PRIMARY KEY NOT NULL,
 	"name" text,
-	"coordiates" text,
+	"coordinates" text,
 	"available" boolean
 );

--- a/backend/drizzle/0000_dashing_next_avengers.sql
+++ b/backend/drizzle/0000_dashing_next_avengers.sql
@@ -7,5 +7,5 @@ CREATE TABLE IF NOT EXISTS "buildings" (
 CREATE TABLE IF NOT EXISTS "rooms" (
 	"id" serial PRIMARY KEY NOT NULL,
 	"name" text,
-	"coordiates" text
+	"coordinates" text
 );

--- a/backend/drizzle/0001_flippant_magma.sql
+++ b/backend/drizzle/0001_flippant_magma.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS "sensors" (
 	"id" text PRIMARY KEY NOT NULL,
-	"room" serial NOT NULL
+	"room" integer NOT NULL
 );
 --> statement-breakpoint
 DO $$ BEGIN

--- a/backend/drizzle/0002_fearless_callisto.sql
+++ b/backend/drizzle/0002_fearless_callisto.sql
@@ -1,4 +1,4 @@
-ALTER TABLE "rooms" ADD COLUMN "building" serial NOT NULL;--> statement-breakpoint
+ALTER TABLE "rooms" ADD COLUMN "building" integer NOT NULL;--> statement-breakpoint
 ALTER TABLE "rooms" ADD COLUMN "description" text;--> statement-breakpoint
 DO $$ BEGIN
  ALTER TABLE "rooms" ADD CONSTRAINT "rooms_building_buildings_id_fk" FOREIGN KEY ("building") REFERENCES "buildings"("id") ON DELETE no action ON UPDATE no action;


### PR DESCRIPTION
There was a spelling error in defining the DB tables. Was "coordiates" and changed to "coordinates". "coordinates" used in the rest of the code, causing API post errors. 