### PR TITLE
Test of removed default values

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -156,8 +156,8 @@ export const setupRoutes = (
     const sensorId = device_mac;
 
     //test
-    const radarState  = 0; //default for test
-    const pirState = false; //default for test
+    //const radarState  = 0; //default for test
+    //const pirState = false; //default for test
   
     updateOccupants(firmwareVersion, sensorId, occupants, radarState, pirState);
     return 'Success';

--- a/frontend/src/lib/data/buildings.ts
+++ b/frontend/src/lib/data/buildings.ts
@@ -2,7 +2,7 @@ import type { Building } from "./protocols"
 
 export const buildings: Building[] = [
   {
-    id: "2",
+    id: "4",
     name: "Idéläran (NC)",
     description: "Idéläran is a free-standing building with a computer room and group rooms. Group rooms EG-3509 - EG-3513 are \"first-serve\"",
     address: "Rännvägen 8",
@@ -14,7 +14,7 @@ export const buildings: Building[] = [
     address: "Maskingränd 2",
   },
   {
-    id: "4",
+    id: "2",
     name: "Fysik-huset (Inactive)",
     description: "Two houses connected by a glass bridge. Has laboratories, classrooms and group rooms in both houses.",
     address: "Kemigården 1",


### PR DESCRIPTION
Removed the default values for pirState and radarState for api/sensors/report/vs135hl.
Also updated id of Idéläran and Fysikhuset since they were swapped in previous branch.